### PR TITLE
Feature/ignore-e501

### DIFF
--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -21,7 +21,7 @@ jobs:
       - name: flake8 Lint
         uses: TrueBrain/actions-flake8@v2
         with:
-          ignore: E203,E701,W503,W504
+          ignore: E203,E501,E701,W503,W504
           max_line_length: 88
           path: src
           plugins: flake8-black flake8-isort flake8-quotes

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,14 +1,12 @@
 {
   "git.ignoreLimitWarning": true,
   "editor.formatOnSave": true,
-  "flake8.args": [
-    "--max-line-length=88"
-  ],
+  "flake8.args": ["--max-line-length=88", "--extend-ignore=E203,E501,E701"],
   "[python]": {
     "editor.codeActionsOnSave": {
       "source.organizeImports.python": "explicit"
     },
     "editor.defaultFormatter": "ms-python.black-formatter",
-    "editor.formatOnSave": true,
+    "editor.formatOnSave": true
   }
 }

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,6 +6,6 @@ description-file=README.md
 
 [flake8]
 max-line-length = 88
-extend-ignore = E203,E701
+extend-ignore = E203,E501,E701
 inline-quotes = double
 exclude = src/kinfin.py,scripts


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request updates the flake8 configuration to ignore E501 (line length) warnings, both in the GitHub Actions workflow and the setup.cfg file, to streamline the linting process.

- **Enhancements**:
    - Updated flake8 configuration to ignore E501 (line length) warnings in both the GitHub Actions workflow and setup.cfg.
- **CI**:
    - Modified the flake8 GitHub Actions workflow to include E501 in the list of ignored warnings.

<!-- Generated by sourcery-ai[bot]: end summary -->