### PR TITLE
Fix: Enable CORS with environment variable for flexible frontend origin.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,4 @@ SEQUENCE_IDS_FILE_PATH=/absolute/path/to/SequenceIDs.txt
 TAXON_IDX_MAPPING_FILE_PATH=/absolute/path/to/taxon_idx_mapping.json
 RESULTS_BASE_DIR=/absolute/path/where/all/results/should/be/stored/
 SESSION_INACTIVITY_THRESHOLD=24
+CORS_ALLOWED_ORIGINS=http://localhost:5173,http://localhost:3000

--- a/src/api/__init__.py
+++ b/src/api/__init__.py
@@ -42,7 +42,7 @@ def run_server(
 
     app = FastAPI()
 
-    ALLOWED_ORIGINS = os.getenv("CORS_ALLOWED_ORIGINS", "http://localhost:5173").split(",")
+    ALLOWED_ORIGINS = [origin.strip() for origin in os.getenv("CORS_ALLOWED_ORIGINS", "http://localhost:5173").split(",")]
 
     app.add_middleware(
     CORSMiddleware,

--- a/src/api/__init__.py
+++ b/src/api/__init__.py
@@ -25,10 +25,12 @@ def run_server(
     - sequence_ids_f [str] : File path to the sequence IDs file.
     """
     import uvicorn
+    import os
     from fastapi import FastAPI
 
     from api.endpoints import router
     from api.sessions import query_manager
+    from fastapi.middleware.cors import CORSMiddleware
 
     query_manager.cluster_f = cluster_f
     query_manager.sequence_ids_f = sequence_ids_f
@@ -39,6 +41,16 @@ def run_server(
     query_manager.go_mapping_f = go_mapping_f
 
     app = FastAPI()
+
+    ALLOWED_ORIGINS = os.getenv("CORS_ALLOWED_ORIGINS", "http://localhost:5173").split(",")
+
+    app.add_middleware(
+    CORSMiddleware,
+    allow_origins=ALLOWED_ORIGINS, 
+    allow_credentials=True,
+    allow_methods=["GET", "POST", "OPTIONS"], 
+    allow_headers=["*"],  
+)
 
     @app.get("/")
     def hello():


### PR DESCRIPTION
## Summary
This PR adds CORS support to the FastAPI backend to enable frontend applications to interact with the API across different origins. The implementation ensures flexibility by allowing origins to be configured via an environment variable.

## Changes Implemented:

- Integrated CORSMiddleware from FastAPI.
- Allowed origins are configurable via the CORS_ALLOWED_ORIGINS environment variable.
- The default origin is set to http://localhost:5173, supporting multiple origins.
- Enabled OPTIONS method to handle preflight requests properly.
- Allowed custom headers as required.

## Testing

- Verified API requests work from http://localhost:5173 and http://localhost:3000.
- Ensured preflight requests are handled correctly.

## Screenshot of the error resolved.
![image](https://github.com/user-attachments/assets/210a6edd-1210-45b6-a22e-433c960fb1e1)

## Issue Reference
Closes #22

## Summary by Sourcery

Enable Cross-Origin Resource Sharing (CORS) to allow requests from different origins. Configure allowed origins via the CORS_ALLOWED_ORIGINS environment variable, defaulting to http://localhost:5173.

Enhancements:
- Add CORS middleware to the FastAPI application.
- Allow configuration of allowed origins via the CORS_ALLOWED_ORIGINS environment variable.
- Enable OPTIONS method to handle preflight requests.
- Allow custom headers.