### PR TITLE
Fix: Pagination and min_count Filtering Issues in /kinfin APIs

### DIFF
--- a/src/api/__init__.py
+++ b/src/api/__init__.py
@@ -24,13 +24,14 @@ def run_server(
     - taxon_idx_mapping_file [str] : File path to the taxon index mapping file.
     - sequence_ids_f [str] : File path to the sequence IDs file.
     """
-    import uvicorn
     import os
+
+    import uvicorn
     from fastapi import FastAPI
+    from fastapi.middleware.cors import CORSMiddleware
 
     from api.endpoints import router
     from api.sessions import query_manager
-    from fastapi.middleware.cors import CORSMiddleware
 
     query_manager.cluster_f = cluster_f
     query_manager.sequence_ids_f = sequence_ids_f
@@ -42,15 +43,20 @@ def run_server(
 
     app = FastAPI()
 
-    ALLOWED_ORIGINS = [origin.strip() for origin in os.getenv("CORS_ALLOWED_ORIGINS", "http://localhost:5173").split(",")]
+    ALLOWED_ORIGINS = [
+        origin.strip()
+        for origin in os.getenv("CORS_ALLOWED_ORIGINS", "http://localhost:5173").split(
+            ","
+        )
+    ]
 
     app.add_middleware(
-    CORSMiddleware,
-    allow_origins=ALLOWED_ORIGINS, 
-    allow_credentials=True,
-    allow_methods=["GET", "POST", "OPTIONS"], 
-    allow_headers=["*"],  
-)
+        CORSMiddleware,
+        allow_origins=ALLOWED_ORIGINS,
+        allow_credentials=True,
+        allow_methods=["GET", "POST", "OPTIONS"],
+        allow_headers=["*"],
+    )
 
     @app.get("/")
     def hello():

--- a/src/api/endpoints.py
+++ b/src/api/endpoints.py
@@ -746,7 +746,6 @@ async def get_pairwise_analysis(
 
         result = parse_pairwise_file(filepath, taxon_1, taxon_2)
 
-       
         if isinstance(result, list):
             result = {str(i): item for i, item in enumerate(result)}
 
@@ -781,6 +780,7 @@ async def get_pairwise_analysis(
             ).model_dump(),
             status_code=500,
         )
+
 
 @router.get("/kinfin/plot/{plot_type}")
 @check_kinfin_session

--- a/src/api/endpoints.py
+++ b/src/api/endpoints.py
@@ -683,6 +683,10 @@ async def get_pairwise_analysis(
     session_id: str = Depends(header_scheme),
     taxon_1: Optional[str] = Query(None),
     taxon_2: Optional[str] = Query(None),
+    sort_by: Optional[str] = Query(None),
+    sort_order: Optional[str] = Query("asc"),
+    page: Optional[int] = Query(1),
+    size: Optional[int] = Query(10),
 ):
     try:
         result_dir = query_manager.get_session_dir(session_id)
@@ -718,7 +722,7 @@ async def get_pairwise_analysis(
             return JSONResponse(
                 content=ResponseSchema(
                     status="error",
-                    message=f"{COUNTS_FILEPATH} File Not Found",
+                    message=f"{PAIRWISE_ANALYSIS_FILE} File Not Found",
                     error="File does not exist",
                     query=str(request.url),
                 ).model_dump(),
@@ -727,14 +731,30 @@ async def get_pairwise_analysis(
 
         result = parse_pairwise_file(filepath, taxon_1, taxon_2)
 
+       
+        if isinstance(result, list):
+            result = {str(i): item for i, item in enumerate(result)}
+
+        paginated_result, total_pages = sort_and_paginate_result(
+            result,
+            sort_by,
+            sort_order,
+            page,
+            size,
+        )
+
         response = ResponseSchema(
             status="success",
-            message="Cluster summary retrieved successfully",
-            data=result,
+            message="Pairwise analysis retrieved successfully",
+            data=paginated_result,
             query=str(request.url),
+            current_page=page,
+            entries_per_page=size,
+            total_pages=total_pages,
         )
 
         return JSONResponse(response.model_dump())
+
     except Exception as e:
         print(e)
         return JSONResponse(
@@ -746,8 +766,6 @@ async def get_pairwise_analysis(
             ).model_dump(),
             status_code=500,
         )
-
-
 @router.get("/kinfin/plot/{plot_type}")
 @check_kinfin_session
 async def get_plot(

--- a/src/api/endpoints.py
+++ b/src/api/endpoints.py
@@ -748,7 +748,6 @@ async def get_pairwise_analysis(
 
         if isinstance(result, list):
             result = {str(i): item for i, item in enumerate(result)}
-
         paginated_result, total_pages = sort_and_paginate_result(
             result,
             sort_by,

--- a/src/api/endpoints.py
+++ b/src/api/endpoints.py
@@ -328,10 +328,10 @@ async def get_counts_by_tanon(
             filepath,
             include_clusters,
             exclude_clusters,
-            min_count,
-            max_count,
             include_taxons,
             exclude_taxons,
+            min_count,
+            max_count,
         )
 
         response = ResponseSchema(


### PR DESCRIPTION
This PR addresses three key issues in the /kinfin APIs:

## Pagination Implementation:

- Added pagination metadata (total_pages, current_page, entries_per_page) to /kinfin/counts-by-taxon and /kinfin/pairwise-analysis/{attribute} APIs.

## Fix for Internal Server Error in min_count Filtering:

- Resolved an issue where querying /kinfin/counts-by-taxon with min_count caused an AttributeError ('int' object has no attribute 'split').
- Fixed parameter misalignment in parse_taxon_counts_file(), ensuring min_count and max_count are correctly processed.

## Closing Issues:
Closes #24, #25, and #26.

## Summary by Sourcery

Enhance /kinfin APIs with pagination support and fix filtering issues in counts and pairwise analysis endpoints

New Features:
- Add pagination support to /kinfin/counts-by-taxon and /kinfin/pairwise-analysis/{attribute} APIs with sorting and pagination parameters

Bug Fixes:
- Resolve AttributeError in min_count filtering for counts-by-taxon endpoint
- Fix parameter processing in parse_taxon_counts_file() to correctly handle min_count and max_count

Enhancements:
- Implement sorting and pagination functionality for API responses
- Add pagination metadata to API responses including total_pages, current_page, and entries_per_page