### PR TITLE
feat(api): Add endpoint to serve taxon_idx_mapping.json for input validation

### DIFF
--- a/src/api/endpoints.py
+++ b/src/api/endpoints.py
@@ -17,7 +17,7 @@ from api.fileparsers import (
     parse_cluster_summary_file,
     parse_pairwise_file,
     parse_taxon_counts_file,
-    parse_valid_taxons_file
+    parse_valid_proteome_ids_file,
 )
 from api.sessions import query_manager
 from api.utils import (
@@ -511,23 +511,31 @@ async def get_valid_taxons_api(
     size: int = Query(10, ge=1, le=100),
 ):
     try:
-        taxons = await asyncio.to_thread(parse_valid_taxons_file, query_manager.taxon_idx_mapping_file)
-        items = list(taxons.items())
-        total_items = len(items)
-        total_pages = (total_items + size - 1) // size
-        start = (page - 1) * size
-        end = start + size
-        paginated_items = dict(items[start:end])
-        response = ResponseSchema(
-            status="success",
-            message="List of valid taxons fetched",
-            data=paginated_items,
-            query=str(request.url),
-            current_page=page,
-            entries_per_page=size,
-            total_pages=total_pages,
+        taxons = await asyncio.to_thread(
+            parse_valid_proteome_ids_file, query_manager.taxon_idx_mapping_file
         )
-        return JSONResponse(response.model_dump(), status_code=200)
+    except FileNotFoundError as e:
+        LOGGER.error("Taxon file not found", exc_info=True)
+        return JSONResponse(
+            content=ResponseSchema(
+                status="error",
+                message="Taxon index file not found",
+                query=str(request.url),
+                error=str(e),
+            ).model_dump(),
+            status_code=404,
+        )
+    except ValueError as e:
+        LOGGER.error("Error parsing taxon index file", exc_info=True)
+        return JSONResponse(
+            content=ResponseSchema(
+                status="error",
+                message="Error parsing taxon index file",
+                query=str(request.url),
+                error=str(e),
+            ).model_dump(),
+            status_code=422,
+        )
     except Exception as e:
         LOGGER.error("Error fetching valid taxons", exc_info=True)
         return JSONResponse(
@@ -539,6 +547,24 @@ async def get_valid_taxons_api(
             ).model_dump(),
             status_code=500,
         )
+
+    items = list(taxons.items())
+    total_items = len(items)
+    total_pages = (total_items + size - 1) // size
+    start = (page - 1) * size
+    end = start + size
+    paginated_items = dict(items[start:end])
+
+    response = ResponseSchema(
+        status="success",
+        message="List of valid proteome IDs fetched",
+        data=paginated_items,
+        query=str(request.url),
+        current_page=page,
+        entries_per_page=size,
+        total_pages=total_pages,
+    )
+    return JSONResponse(response.model_dump(), status_code=200)
 
 
 @router.get("/kinfin/attribute-summary/{attribute}", response_model=ResponseSchema)

--- a/src/api/fileparsers.py
+++ b/src/api/fileparsers.py
@@ -1,6 +1,7 @@
 import csv
-from typing import Optional, Set, Union
 import json
+from typing import Optional, Set, Union
+
 
 def read_tsv_file(filepath: str, delimiter: str = "\t"):
     try:
@@ -246,6 +247,7 @@ def parse_pairwise_file(filepath: str, taxon_1: Optional[str], taxon_2: Optional
 
     return result
 
-def parse_valid_taxons_file(filepath: str) -> dict:
+
+def parse_valid_proteome_ids_file(filepath: str) -> dict:
     with open(filepath, "r") as f:
         return json.load(f)


### PR DESCRIPTION
- Introduced /kinfin/taxon-list endpoint
- Reads and returns data from taxon_idx_mapping.json
- Does not require session ID
- Supports UI-side validation for input datasets (addresses issue #41)

## Summary by Sourcery

Add an endpoint to serve and paginate valid taxons from the taxon index mapping file for client-side input validation

New Features:
- Introduce GET /kinfin/valid-taxons endpoint to return paginated valid taxons without requiring a session
- Add parse_valid_taxons_file utility to load taxon_idx_mapping.json for use by the new endpoint