### PR TITLE
refactor(toasts): display only the necessary toast notification to reduce clutter

### DIFF
--- a/src/ui/src/app/store/analysis/saga.js
+++ b/src/ui/src/app/store/analysis/saga.js
@@ -28,10 +28,7 @@ import {
   getRunSummaryFailure,
   getRunSummarySuccess,
 } from "./actions";
-import {
-  dispatchErrorToast,
-  dispatchSuccessToast,
-} from "../../../utilis/tostNotifications";
+import { dispatchErrorToast } from "../../../utilis/tostNotifications";
 import {
   getAvailableAttributes,
   getCountsByTaxon,
@@ -62,7 +59,6 @@ function* getAvailableAttributesSaga() {
 
     if (response.status === "success") {
       yield put(getAvailableAttributesTaxonsetsSuccess(response.data));
-      yield call(dispatchSuccessToast, "Attributes fetched successfully!");
     } else {
       yield put(getAvailableAttributesTaxonsetsFailure(response));
       yield call(
@@ -89,7 +85,6 @@ function* getRunSummarySaga() {
 
     if (response.status === "success") {
       yield put(getRunSummarySuccess(response.data));
-      yield call(dispatchSuccessToast, "Run Summary fetched successfully!");
     } else {
       yield put(getRunSummaryFailure(response));
       yield call(
@@ -116,7 +111,6 @@ function* getCountsByTaxonSaga() {
 
     if (response.status === "success") {
       yield put(getCountsByTaxonSuccess(response.data));
-      yield call(dispatchSuccessToast, "Counts by taxon fetched successfully!");
     } else {
       yield put(getCountsByTaxonFailure(response));
       yield call(
@@ -149,7 +143,6 @@ function* getClusterSummarySaga(action) {
 
     if (response.status === "success") {
       yield put(getClusterSummarySuccess(response));
-      yield call(dispatchSuccessToast, "Cluster Summary fetched successfully!");
     } else {
       yield put(getClusterSummaryFailure(response));
       yield call(
@@ -182,10 +175,6 @@ function* getAttributeSummarySaga(action) {
 
     if (response.status === "success") {
       yield put(getAttributeSummarySuccess(response));
-      yield call(
-        dispatchSuccessToast,
-        "Attribute Summary fetched successfully!"
-      );
     } else {
       yield put(getAttributeSummaryFailure(response));
       yield call(
@@ -219,7 +208,6 @@ function* getClusterMetricsSaga(action) {
 
     if (response.status === "success") {
       yield put(getClusterMetricsSuccess(response));
-      yield call(dispatchSuccessToast, "Cluster Metrics fetched successfully!");
     } else {
       yield put(getClusterMetricsFailure(response));
       yield call(
@@ -247,10 +235,6 @@ function* getPairwiseAnalysisSaga(action) {
 
     if (response.status === "success") {
       yield put(getPairwiseAnalysisSuccess(response.data));
-      yield call(
-        dispatchSuccessToast,
-        "Pairwise Analysis fetched successfully!"
-      );
     } else {
       yield put(getPairwiseAnalysisFailure(response));
       yield call(

--- a/src/ui/src/app/store/config/saga.js
+++ b/src/ui/src/app/store/config/saga.js
@@ -111,10 +111,6 @@ function* initAnalysisSaga(action) {
         sessionId: response.data.session_id,
       };
       yield put(storeConfig(payloadForIndexDBStorage));
-      yield call(
-        dispatchSuccessToast,
-        "KinFin analysis has started. Please wait..."
-      );
       yield call(navigate, `/${response.data.session_id}/dashboard`);
       yield fork(pollRunStatusSaga, response.data.session_id); // start polling
     } else {
@@ -143,7 +139,6 @@ function* getRunStatusSaga() {
     const response = yield call(getStatus);
     if (response.status === "success") {
       yield put(getRunStatusSuccess(response.data));
-      yield call(dispatchSuccessToast, "Run status fetched successfully!");
     } else {
       yield put(getRunStatusFailure(response));
       yield call(
@@ -169,10 +164,6 @@ function* getValidProteomeIdsSaga(action) {
 
     if (response.status === "success") {
       yield put(getValidProteomeIdsSuccess(response.data));
-      yield call(
-        dispatchSuccessToast,
-        "Valid proteome IDs fetched successfully!"
-      );
     } else {
       yield put(getValidProteomeIdsFailure(response));
       yield call(
@@ -194,7 +185,7 @@ export function* getBatchStatusSaga(action) {
     const response = yield call(getBatchStatus, sessionIds);
     if (response.status === "success") {
       yield put(getBatchStatusSuccess(response.data));
-      yield call(dispatchSuccessToast, "Batch status fetched successfully!");
+
       for (const session of response.data.sessions) {
         const isActive = session.status === "completed";
 


### PR DESCRIPTION
## Summary by Sourcery

Streamline toast notifications by removing non-essential success toasts from multiple data‐fetch and config sagas to reduce UI clutter.

Enhancements:
- Remove dispatchSuccessToast calls for various analysis sagas (attributes, run summary, counts by taxon, cluster summary, attribute summary, cluster metrics, pairwise analysis)
- Remove dispatchSuccessToast calls for config sagas (init analysis, run status, valid proteome IDs, batch status)