### PR TITLE
feat: add per-route rate limiting support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ networkx==3.3
 powerlaw==1.5
 ete3==3.1.3
 fastapi==0.111.0
+slowapi==0.1.9

--- a/src/api/__init__.py
+++ b/src/api/__init__.py
@@ -1,10 +1,10 @@
 from fastapi.responses import JSONResponse
-from slowapi import Limiter
 from slowapi.errors import RateLimitExceeded
-from slowapi.util import get_remote_address
 
 from api.utils import load_clustering_datasets
 from core.input import ServeArgs
+
+from .core.limiter import limiter
 
 
 def run_server(
@@ -52,7 +52,6 @@ def run_server(
     query_manager.go_mapping_f = go_mapping_f
 
     app = FastAPI()
-    limiter = Limiter(key_func=get_remote_address)
     app.state.limiter = limiter
 
     @app.exception_handler(RateLimitExceeded)

--- a/src/api/config/limits.py
+++ b/src/api/config/limits.py
@@ -1,0 +1,6 @@
+# src/config/limits.py
+import os
+
+LIMIT_INIT = os.getenv("KINFIN_LIMIT_INIT", "1/minute")
+LIMIT_STANDARD = os.getenv("KINFIN_LIMIT_STANDARD", "60/minute")
+LIMIT_LOW = os.getenv("KINFIN_LIMIT_LOW", "300/minute")

--- a/src/api/core/limiter.py
+++ b/src/api/core/limiter.py
@@ -1,0 +1,4 @@
+from slowapi import Limiter
+from slowapi.util import get_remote_address
+
+limiter = Limiter(key_func=get_remote_address)

--- a/src/api/endpoints.py
+++ b/src/api/endpoints.py
@@ -12,8 +12,6 @@ from fastapi import APIRouter, Body, Depends, HTTPException, Query, Request
 from fastapi.responses import FileResponse, JSONResponse, StreamingResponse
 from fastapi.security import APIKeyHeader
 from pydantic import BaseModel
-from slowapi import Limiter
-from slowapi.util import get_remote_address
 
 from api.fileparsers import (
     parse_attribute_summary_file,
@@ -35,6 +33,8 @@ from api.utils import (
 )
 from core.utils import check_file
 
+from .core.limiter import limiter
+
 LOGGER = logging.getLogger("uvicorn.error")
 LOGGER.setLevel(logging.DEBUG)
 
@@ -45,7 +45,7 @@ ATTRIBUTE_METRICS_FILENAME = "attribute_metrics.txt"
 CLUSTER_METRICS_FILENAME = "cluster_metrics.txt"
 PAIRWISE_ANALYSIS_FILE = "pairwise_representation_test.txt"
 
-limiter = Limiter(key_func=get_remote_address)
+
 router = APIRouter()
 
 
@@ -743,7 +743,7 @@ async def get_valid_taxons_api(
 
 
 @router.get("/kinfin/clustering-sets", response_model=ResponseSchema)
-@limiter.limit("60/minute")
+@limiter.limit("2/minute")
 async def get_clustering_sets_api(
     request: Request,
     page: int = Query(1, ge=1),

--- a/src/api/endpoints.py
+++ b/src/api/endpoints.py
@@ -33,6 +33,7 @@ from api.utils import (
 )
 from core.utils import check_file
 
+from .config.limits import LIMIT_INIT, LIMIT_STANDARD
 from .core.limiter import limiter
 
 LOGGER = logging.getLogger("uvicorn.error")
@@ -172,7 +173,7 @@ def get_session_status(session_id: str) -> Dict:
 
 
 @router.post("/kinfin/init", response_model=ResponseSchema)
-@limiter.limit("1/minute")
+@limiter.limit(LIMIT_INIT)
 async def initialize(input_data: InputSchema, request: Request):
     """
     Initialize the analysis process.
@@ -283,7 +284,7 @@ async def initialize(input_data: InputSchema, request: Request):
 
 
 @router.get("/kinfin/status", response_model=ResponseSchema)
-@limiter.limit("60/minute")
+@limiter.limit(LIMIT_STANDARD)
 @check_kinfin_session
 async def get_run_status(request: Request, session_id: str = Depends(header_scheme)):
     try:
@@ -311,7 +312,7 @@ async def get_run_status(request: Request, session_id: str = Depends(header_sche
 
 
 @router.post("/kinfin/status", response_model=ResponseSchema)
-@limiter.limit("60/minute")
+@limiter.limit(LIMIT_STANDARD)
 async def get_batch_status(request: Request, session_ids: List[str] = Body(...)):
     try:
         statuses = [get_session_status(session_id) for session_id in session_ids]
@@ -338,7 +339,7 @@ async def get_batch_status(request: Request, session_ids: List[str] = Body(...))
 
 
 @router.get("/kinfin/run-summary", response_model=ResponseSchema)
-@limiter.limit("60/minute")
+@limiter.limit(LIMIT_STANDARD)
 @check_kinfin_session
 async def get_run_summary(
     request: Request,
@@ -390,7 +391,7 @@ async def get_run_summary(
 
 
 @router.get("/kinfin/counts-by-taxon", response_model=ResponseSchema)
-@limiter.limit("60/minute")
+@limiter.limit(LIMIT_STANDARD)
 @check_kinfin_session
 async def get_counts_by_tanon(
     request: Request,
@@ -463,7 +464,7 @@ async def get_counts_by_tanon(
 
 
 @router.get("/kinfin/cluster-summary/{attribute}", response_model=ResponseSchema)
-@limiter.limit("60/minute")
+@limiter.limit(LIMIT_STANDARD)
 @check_kinfin_session
 async def get_cluster_summary(
     request: Request,
@@ -618,7 +619,7 @@ async def get_cluster_summary(
 
 
 @router.get("/kinfin/available-attributes-taxonsets")
-@limiter.limit("60/minute")
+@limiter.limit(LIMIT_STANDARD)
 @check_kinfin_session
 async def get_available_attributes_and_taxon_sets(
     request: Request,
@@ -650,7 +651,7 @@ async def get_available_attributes_and_taxon_sets(
 
 
 @router.get("/kinfin/valid-proteome-ids", response_model=ResponseSchema)
-@limiter.limit("60/minute")
+@limiter.limit(LIMIT_STANDARD)
 async def get_valid_taxons_api(
     request: Request,
     clusterId: str,
@@ -743,7 +744,7 @@ async def get_valid_taxons_api(
 
 
 @router.get("/kinfin/clustering-sets", response_model=ResponseSchema)
-@limiter.limit("2/minute")
+@limiter.limit(LIMIT_STANDARD)
 async def get_clustering_sets_api(
     request: Request,
     page: int = Query(1, ge=1),
@@ -809,7 +810,7 @@ async def get_clustering_sets_api(
 
 
 @router.get("/kinfin/attribute-summary/{attribute}", response_model=ResponseSchema)
-@limiter.limit("60/minute")
+@limiter.limit(LIMIT_STANDARD)
 @check_kinfin_session
 async def get_attribute_summary(
     request: Request,
@@ -926,7 +927,7 @@ async def get_attribute_summary(
     "/kinfin/cluster-metrics/{attribute}/{taxon_set}",
     response_model=ResponseSchema,
 )
-@limiter.limit("60/minute")
+@limiter.limit(LIMIT_STANDARD)
 @check_kinfin_session
 async def get_cluster_metrics(
     request: Request,
@@ -1072,7 +1073,7 @@ async def get_cluster_metrics(
     "/kinfin/pairwise-analysis/{attribute}",
     response_model=ResponseSchema,
 )
-@limiter.limit("60/minute")
+@limiter.limit(LIMIT_STANDARD)
 @check_kinfin_session
 async def get_pairwise_analysis(
     request: Request,
@@ -1165,7 +1166,7 @@ async def get_pairwise_analysis(
 
 @router.get("/kinfin/plot/{plot_type}")
 @check_kinfin_session
-@limiter.limit("60/minute")
+@limiter.limit(LIMIT_STANDARD)
 async def get_plot(
     request: Request,
     plot_type: str,

--- a/src/ui/README.md
+++ b/src/ui/README.md
@@ -64,6 +64,9 @@ Start the backend API:
 export KINFIN_PORT=8000
 export RESULTS_BASE_DIR=$KINFIN_WORKDIR/output
 export SESSION_INACTIVITY_THRESHOLD=24  # Files retained for 24 hours
+export KINFIN_LIMIT_INIT=1/minute
+export KINFIN_LIMIT_STANDARD=60/minute
+export KINFIN_LIMIT_LOW=300/minute
 
 ./src/main.py serve -p $KINFIN_PORT
 ```


### PR DESCRIPTION
- Integrated SlowAPI for rate limiting
- Each API route can now be configured with individual rate limits

## Summary by Sourcery

Add per-route rate limiting support to the FastAPI server

New Features:
- Integrate SlowAPI to enforce rate limits on API routes
- Add a global exception handler to return HTTP 429 when limits are exceeded
- Apply individual rate limits: 1 request/minute for initialization and 60 requests/minute for other routes