### PR TITLE
fix: made Data Table into MUI.

### DIFF
--- a/src/ui/package-lock.json
+++ b/src/ui/package-lock.json
@@ -6787,6 +6787,11 @@
       "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
       "dev": true
     },
+    "node_modules/classnames": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow=="
+    },
     "node_modules/cliui": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
@@ -11144,6 +11149,39 @@
         }
       ]
     },
+    "node_modules/rc-tooltip": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/rc-tooltip/-/rc-tooltip-6.4.0.tgz",
+      "integrity": "sha512-kqyivim5cp8I5RkHmpsp1Nn/Wk+1oeloMv9c7LXNgDxUpGm+RbXJGL+OPvDlcRnx9DBeOe4wyOIl4OKUERyH1g==",
+      "dependencies": {
+        "@babel/runtime": "^7.11.2",
+        "@rc-component/trigger": "^2.0.0",
+        "classnames": "^2.3.1",
+        "rc-util": "^5.44.3"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/rc-util": {
+      "version": "5.44.4",
+      "resolved": "https://registry.npmjs.org/rc-util/-/rc-util-5.44.4.tgz",
+      "integrity": "sha512-resueRJzmHG9Q6rI/DfK6Kdv9/Lfls05vzMs1Sk3M2P+3cJa+MakaZyWY8IPfehVuhPJFKrIY1IK4GqbiaiY5w==",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "react-is": "^18.2.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/rc-util/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="
+    },
     "node_modules/react": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
@@ -11210,6 +11248,14 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.5.0.tgz",
+      "integrity": "sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-is": {

--- a/src/ui/src/components/FileUpload/DataTable/DataTable.module.scss
+++ b/src/ui/src/components/FileUpload/DataTable/DataTable.module.scss
@@ -1,33 +1,3 @@
-table {
-  width: 100%;
-  border-collapse: collapse;
-  color: var(--text-color);
-  margin-top: 1rem;
-}
-
-th,
-td {
-  border: 1px solid var(--table-border);
-  padding: 8px 10px;
-  text-align: left;
-  font-family: monospace;
-}
-
-th {
-  background-color: var(--th-bg);
-  color: var(--text-color);
-}
-
-tr:nth-child(even) {
-  background-color: var(--alt-row);
-}
-
-.invalidTaxonCell {
-  background-color: var(--error-color);
-  color: var(--text-color);
-  font-weight: bold;
-  border-radius: 4px;
-}
 .invalidCell {
   border: 2px solid red !important;
   background-color: #ffe6e6;
@@ -35,5 +5,5 @@ tr:nth-child(even) {
 
 .invalidHeader {
   border: 2px solid red !important;
-  background-color: #ffe6e6;
+  background-color: #ffe6e6 !important;
 }

--- a/src/ui/src/components/FileUpload/DataTable/index.jsx
+++ b/src/ui/src/components/FileUpload/DataTable/index.jsx
@@ -1,4 +1,14 @@
 import React from "react";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Paper,
+  Typography,
+} from "@mui/material";
 import styles from "./DataTable.module.scss";
 
 const DataTable = ({
@@ -6,90 +16,101 @@ const DataTable = ({
   validationErrors = { headers: [], rows: [] },
   handleHeaderEdit = () => {},
   handleCellEdit = () => {},
-  allowEdit = true, // default true
+  allowEdit = true,
 }) => {
-  if (!Array.isArray(parsedData)) return <p>Data is not in tabular format.</p>;
-  if (parsedData.length === 0) return <p>No data to display.</p>;
+  if (!Array.isArray(parsedData)) {
+    return <Typography>Data is not in tabular format.</Typography>;
+  }
+  if (parsedData.length === 0) {
+    return <Typography>No data to display.</Typography>;
+  }
 
   const headers = Object.keys(parsedData[0]);
 
   return (
-    <table className={styles.table}>
-      <thead>
-        <tr>
-          {headers.map((head) => {
-            const hasHeaderError = allowEdit
-              ? validationErrors.headers.some((err) => err.includes(head))
-              : false;
-
-            const headerErrorMsg = allowEdit
-              ? validationErrors.headers.find((err) =>
-                  err.toLowerCase().includes(`'${head.trim().toLowerCase()}'`)
-                )
-              : "";
-
-            return (
-              <th
-                key={head}
-                className={hasHeaderError ? styles.invalidHeader : ""}
-                title={hasHeaderError ? headerErrorMsg : ""}
-              >
-                {allowEdit ? (
-                  <div
-                    contentEditable
-                    suppressContentEditableWarning
-                    onBlur={(e) => {
-                      const newHeader = e.target.textContent.trim();
-                      if (newHeader && newHeader !== head) {
-                        handleHeaderEdit(head, newHeader);
-                      }
-                    }}
-                    onKeyDown={(e) => {
-                      if (e.key === "Enter") {
-                        e.preventDefault();
-                        e.target.blur();
-                      }
-                    }}
-                    style={{ minWidth: "100px", padding: "4px" }}
-                  >
-                    {head}
-                  </div>
-                ) : (
-                  <div style={{ minWidth: "100px", padding: "4px" }}>
-                    {head}
-                  </div>
-                )}
-              </th>
-            );
-          })}
-        </tr>
-      </thead>
-      <tbody>
-        {parsedData.map((row, idx) => (
-          <tr key={idx}>
+    <TableContainer
+      component={Paper}
+      sx={{
+        maxHeight: 300,
+        overflowY: "auto",
+      }}
+    >
+      <Table stickyHeader size="small">
+        <TableHead>
+          <TableRow>
             {headers.map((head) => {
-              const cellError =
-                allowEdit && validationErrors.rows?.[idx]?.[head];
+              const hasHeaderError = allowEdit
+                ? validationErrors.headers.some((err) => err.includes(head))
+                : false;
+
+              const headerErrorMsg = allowEdit
+                ? validationErrors.headers.find((err) =>
+                    err.toLowerCase().includes(`'${head.trim().toLowerCase()}'`)
+                  )
+                : "";
 
               return (
-                <td
+                <TableCell
                   key={head}
-                  className={cellError ? styles.invalidCell : ""}
-                  title={cellError || ""}
-                  {...(allowEdit && {
-                    contentEditable: true,
-                    suppressContentEditableWarning: true,
-                    onBlur: (e) => handleCellEdit(e, idx, head),
-                  })}
+                  className={hasHeaderError ? styles.invalidHeader : ""}
+                  title={hasHeaderError ? headerErrorMsg : ""}
+                  sx={{ fontWeight: "bold", backgroundColor: "var(--th-bg)" }}
                 >
-                  {row[head]?.toString() || ""}
-                </td>
+                  {allowEdit ? (
+                    <div
+                      contentEditable
+                      suppressContentEditableWarning
+                      onBlur={(e) => {
+                        const newHeader = e.target.textContent.trim();
+                        if (newHeader && newHeader !== head) {
+                          handleHeaderEdit(head, newHeader);
+                        }
+                      }}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter") {
+                          e.preventDefault();
+                          e.target.blur();
+                        }
+                      }}
+                      style={{ minWidth: "100px", padding: "4px" }}
+                    >
+                      {head}
+                    </div>
+                  ) : (
+                    head
+                  )}
+                </TableCell>
               );
             })}
-          </tr>
-        ))}
-      </tbody>
-    </table>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {parsedData.map((row, idx) => (
+            <TableRow key={idx}>
+              {headers.map((head) => {
+                const cellError =
+                  allowEdit && validationErrors.rows?.[idx]?.[head];
+
+                return (
+                  <TableCell
+                    key={head}
+                    className={cellError ? styles.invalidCell : ""}
+                    title={cellError || ""}
+                    {...(allowEdit && {
+                      contentEditable: true,
+                      suppressContentEditableWarning: true,
+                      onBlur: (e) => handleCellEdit(e, idx, head),
+                    })}
+                  >
+                    {row[head]?.toString() || ""}
+                  </TableCell>
+                );
+              })}
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </TableContainer>
   );
 };
 

--- a/src/ui/src/components/FileUpload/DataTable/index.jsx
+++ b/src/ui/src/components/FileUpload/DataTable/index.jsx
@@ -100,6 +100,12 @@ const DataTable = ({
                       contentEditable: true,
                       suppressContentEditableWarning: true,
                       onBlur: (e) => handleCellEdit(e, idx, head),
+                      onKeyDown: (e) => {
+                        if (e.key === "Enter") {
+                          e.preventDefault();
+                          e.target.blur();
+                        }
+                      },
                     })}
                   >
                     {row[head]?.toString() || ""}

--- a/src/ui/src/components/FileUpload/FileUpload.module.scss
+++ b/src/ui/src/components/FileUpload/FileUpload.module.scss
@@ -53,3 +53,7 @@
     color: var(--bg-color);
   }
 }
+
+h4 {
+  margin: 0;
+}

--- a/src/ui/src/pages/define-node-labels/DefineNodeLabels.module.scss
+++ b/src/ui/src/pages/define-node-labels/DefineNodeLabels.module.scss
@@ -86,7 +86,7 @@
 .workflowStep {
   background: white;
   border-radius: 12px;
-  padding: 24px;
+  padding: 12px;
   margin-bottom: 20px;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
   transition: all 0.3s;


### PR DESCRIPTION
- AT any time only 7 rows are shown, and rest can be seen on scroll
- At any time user can see 3 stpes of define-node-labels.
- Closes #74 
<img width="1851" height="963" alt="image" src="https://github.com/user-attachments/assets/d9f82708-c05f-4682-866c-7f4c1efa6228" />

## Summary by Sourcery

Migrate the custom DataTable component to use MUI Table components with a fixed height scrollable container and sticky headers, and apply related style updates across DataTable, FileUpload, and DefineNodeLabels views.

Enhancements:
- Replace the HTML table in DataTable with MUI Table, TableContainer, Paper, and Typography components
- Limit DataTable display height and enable vertical scrolling with a sticky header
- Use MUI Typography for empty and invalid data messages
- Remove custom table SCSS in favor of MUI styling, retaining only error highlight styles
- Add margin reset to FileUpload h4 elements
- Reduce padding on DefineNodeLabels workflow steps to adjust visible content