### PR TITLE
fxi: clusterId was missing during re-initailisation.

### DIFF
--- a/src/ui/src/components/AttributeSelector/index.jsx
+++ b/src/ui/src/components/AttributeSelector/index.jsx
@@ -28,7 +28,39 @@ const AttributeSelector = () => {
   const [attribute, setAttribute] = useState(initialAttribute);
   const [taxon, setTaxon] = useState(initialTaxon);
 
-  // Apply selection when URL params change
+  useEffect(() => {
+    if (responseData && (!initialAttribute || !initialTaxon)) {
+      const firstAttribute = responseData.attributes?.[0];
+      const firstTaxonset = firstAttribute
+        ? responseData.taxon_set?.[firstAttribute]?.[0]
+        : null;
+
+      if (firstAttribute && firstTaxonset) {
+        const newAttribute = initialAttribute || firstAttribute;
+        const newTaxonset = initialTaxon || firstTaxonset;
+
+        setAttribute(newAttribute);
+        setTaxon(newTaxonset);
+
+        setSearchParams(
+          {
+            attribute: newAttribute,
+            taxonset: newTaxonset,
+          },
+          { replace: true }
+        );
+
+        dispatch(
+          setSelectedAttributeTaxonset({
+            attribute: newAttribute,
+            taxonset: newTaxonset,
+          })
+        );
+      }
+    }
+  }, [responseData, initialAttribute, initialTaxon, setSearchParams, dispatch]);
+
+  // Apply selection when URL params change (existing functionality)
   useEffect(() => {
     if (initialAttribute && initialTaxon) {
       dispatch(

--- a/src/ui/src/pages/dashboard/index.jsx
+++ b/src/ui/src/pages/dashboard/index.jsx
@@ -78,6 +78,7 @@ const Dashboard = () => {
     const payload = {
       name: sessionDetails.name,
       config: sessionDetails.config,
+      clusterId: sessionDetails.clusterId,
       navigate,
     };
     dispatch(initAnalysis(payload));


### PR DESCRIPTION
-By default 1st value of attribute and taxonsset will be set in params.
- Closes #73

## Summary by Sourcery

Ensure default selections for attribute and taxonset are applied when URL parameters are missing and restore the missing clusterId in the analysis initialization

Bug Fixes:
- Include clusterId in the initAnalysis payload during dashboard re-initialization

Enhancements:
- Automatically select the first attribute and taxonset and update URL params and state when none are provided