### PR TITLE
Feature/set-clustering-path

### DIFF
--- a/src/api/__init__.py
+++ b/src/api/__init__.py
@@ -36,9 +36,11 @@ def run_server(
     from fastapi import FastAPI
     from fastapi.middleware.cors import CORSMiddleware
 
-    current_dir = os.path.dirname(__file__)
-    dataset_path = os.path.join(current_dir, "clustering.json")
-    load_clustering_datasets(dataset_path)
+    clustering_file_path = os.getenv("KINFIN_CLUSTERING_FILE")
+    if not clustering_file_path:
+        current_dir = os.path.dirname(os.path.abspath(__file__))
+        clustering_file_path = os.path.join(current_dir, "clustering.json")
+    load_clustering_datasets(clustering_file_path)
 
     from api.endpoints import router
     from api.sessions import query_manager

--- a/src/api/endpoints.py
+++ b/src/api/endpoints.py
@@ -831,8 +831,10 @@ async def get_clustering_sets_api(
     size: int = Query(10, ge=1, le=100),
 ):
     try:
-        current_dir = os.path.dirname(os.path.abspath(__file__))
-        clustering_file_path = os.path.join(current_dir, "clustering.json")
+        clustering_file_path = os.getenv("KINFIN_CLUSTERING_FILE")
+        if not clustering_file_path:
+            current_dir = os.path.dirname(os.path.abspath(__file__))
+            clustering_file_path = os.path.join(current_dir, "clustering.json")
 
         clustering_data = await asyncio.to_thread(
             parse_clustering_file, clustering_file_path

--- a/src/ui/README.md
+++ b/src/ui/README.md
@@ -67,6 +67,8 @@ export SESSION_INACTIVITY_THRESHOLD=24  # Files retained for 24 hours
 export KINFIN_LIMIT_INIT=1/minute
 export KINFIN_LIMIT_STANDARD=60/minute
 export KINFIN_LIMIT_LOW=300/minute
+# optionally define a custom clustering file path
+# export KINFIN_CLUSTERING_FILE="/path/to/clustering.json"
 
 ./src/main.py serve -p $KINFIN_PORT
 ```


### PR DESCRIPTION
Adds support for specifying the path to a clustering config json file towards #58

## Summary by Sourcery

Enable configurable clustering config path through an environment variable and update documentation accordingly

New Features:
- Allow specifying a custom clustering configuration file path via the KINFIN_CLUSTERING_FILE environment variable with fallback to the default clustering.json

Documentation:
- Document the KINFIN_CLUSTERING_FILE environment variable in the UI README